### PR TITLE
add support for worker environments

### DIFF
--- a/packages/drizzle-d1-helpers/README.md
+++ b/packages/drizzle-d1-helpers/README.md
@@ -34,6 +34,11 @@ const helper = D1Helper.get("MY_D1_DB");
 // If you have more than 1 binding, this code will throw
 
 const helper2 = D1Helper.get();
+
+
+// If you have bindings defined for a specific worker environment
+
+const developmentEnvHelper = D1Helper.get("MY_D1_DB", {environment: "development"})
 ```
 
 ## Get proxy credentials

--- a/packages/drizzle-d1-helpers/README.md
+++ b/packages/drizzle-d1-helpers/README.md
@@ -100,7 +100,7 @@ useLocalD1("MY_D1", async (db) => {
    // do work
 });
 
-useLocalD1("MY_D1", async (db) => {}, {environment: "staging"});
+useLocalD1("MY_D1", async (db) => {}, "staging");
 ```
 
 # Happy Coding!

--- a/packages/drizzle-d1-helpers/README.md
+++ b/packages/drizzle-d1-helpers/README.md
@@ -38,7 +38,7 @@ const helper2 = D1Helper.get();
 
 // If you have bindings defined for a specific worker environment
 
-const developmentEnvHelper = D1Helper.get("MY_D1_DB", {environment: "development"})
+const stagingEnvHelper = D1Helper.get("MY_D1_DB", {environment: "staging"})
 ```
 
 ## Get proxy credentials
@@ -99,6 +99,8 @@ useProxyD1({ accoundId, token, databaseId }, async () => {
 useLocalD1("MY_D1", async (db) => {
    // do work
 });
+
+useLocalD1("MY_D1", async (db) => {}, {environment: "staging"});
 ```
 
 # Happy Coding!

--- a/packages/drizzle-d1-helpers/src/d1-helper.ts
+++ b/packages/drizzle-d1-helpers/src/d1-helper.ts
@@ -122,7 +122,7 @@ export class D1Helper {
 	}
 
 	async useLocalD1<Env>(doWerk: Parameters<typeof useLocalD1>[1]) {
-		return useLocalD1(this.binding as keyof Env, doWerk)
+		return useLocalD1(this.binding as keyof Env, doWerk, this.#environment)
 	}
 
 	async useProxyD1(doWerk: Parameters<typeof useProxyD1>[1]

--- a/packages/drizzle-d1-helpers/src/d1-helper.ts
+++ b/packages/drizzle-d1-helpers/src/d1-helper.ts
@@ -6,28 +6,30 @@ import { useLocalD1, useProxyD1 } from "./use-helpers"
 
 export type { BoundD1, ProxyD1 } from "./use-helpers"
 
-
+type D1HelperOpts = {environment?: string}
 export class D1Helper {
 	#requestedBinding: string
 	#cfg?: ReturnType<typeof loadRawD1Config>
+	#environment?: string
 
 	#cfAccountId?: string
 	#cfToken?: string
 	#persistToDir?: string // accomodate getPlatformProxy's persistTo  or wrangler cli's --persist-to
 
-	private constructor(binding = "") {
+	private constructor(binding = "", opts?: D1HelperOpts) {
 		// save binding name for lazy config loading later
 		// because not all usecases require explicit config file loading
 		this.#requestedBinding = binding
+		this.#environment = opts?.environment;
 	}
 
-	static get(bindingName?: string) {
-		return new D1Helper(bindingName)
+	static get(bindingName?: string, opts?: D1HelperOpts) {
+		return new D1Helper(bindingName, opts)
 	}
 
 	get #c() {
 		if (!this.#cfg) {
-			this.#cfg = loadRawD1Config(this.#requestedBinding)
+			this.#cfg = loadRawD1Config(this.#requestedBinding, this.#environment)
 		}
 		return this.#cfg
 	}
@@ -130,8 +132,8 @@ export class D1Helper {
 }
 
 
-function loadRawD1Config(bindingName?: string) {
-	const fullCfg = unstable_readConfig({})
+function loadRawD1Config(bindingName?: string, environment?: string) {
+	const fullCfg = unstable_readConfig({env: environment})
 	const { d1_databases, configPath } = fullCfg
 
 	if (!bindingName && d1_databases.length > 1) {

--- a/packages/drizzle-d1-helpers/src/use-helpers.ts
+++ b/packages/drizzle-d1-helpers/src/use-helpers.ts
@@ -5,8 +5,8 @@ import { drizzle as drizzleD1Proxy } from "@nerdfolio/drizzle-d1-proxy"
 export type BoundD1 = ReturnType<typeof drizzleD1>
 export type ProxyD1 = ReturnType<typeof drizzleD1Proxy>
 
-export async function useLocalD1<Env>(bindingName: keyof Env, doWerk: (db: BoundD1) => Promise<void>, opts?: {environment?: string}) {
-	const platform = await getPlatformProxy<Env>({environment: opts?.environment})
+export async function useLocalD1<Env>(bindingName: keyof Env, doWerk: (db: BoundD1) => Promise<void>, environment?: string) {
+	const platform = await getPlatformProxy<Env>({environment})
 
 	const binding = platform.env[bindingName]
 	if (!binding) {

--- a/packages/drizzle-d1-helpers/src/use-helpers.ts
+++ b/packages/drizzle-d1-helpers/src/use-helpers.ts
@@ -5,8 +5,8 @@ import { drizzle as drizzleD1Proxy } from "@nerdfolio/drizzle-d1-proxy"
 export type BoundD1 = ReturnType<typeof drizzleD1>
 export type ProxyD1 = ReturnType<typeof drizzleD1Proxy>
 
-export async function useLocalD1<Env>(bindingName: keyof Env, doWerk: (db: BoundD1) => Promise<void>) {
-	const platform = await getPlatformProxy<Env>()
+export async function useLocalD1<Env>(bindingName: keyof Env, doWerk: (db: BoundD1) => Promise<void>, opts?: {environment?: string}) {
+	const platform = await getPlatformProxy<Env>({environment: opts?.environment})
 
 	const binding = platform.env[bindingName]
 	if (!binding) {


### PR DESCRIPTION
This PR adds support for worker environments.

Fixes https://github.com/nerdfolio/cloudflare-helpers/issues/1

## Usage
```typescript
const helper = D1Helper.get("MY_D1_DB");
const stagingHelper = D1Helper.get("MY_D1_DB", {environment: "development"});

useLocalD1("MY_D1_DB", async (db) => {}, {environment: "staging"});
```